### PR TITLE
New API: named request functions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,8 @@
                                         :git/sha "65ed4c07333994faf98a6e6309800338c3577d4c"}
          org.babashka/http-client      {:mvn/version "0.4.21"}
          org.babashka/json             {:mvn/version "0.1.6"}
-         org.clojure/tools.logging     {:mvn/version "1.3.0"}}
+         org.clojure/tools.logging     {:mvn/version "1.3.0"}
+         org.clojure/core.memoize      {:mvn/version "1.1.266"}}
  :paths ["src" "test"]
 
  :aliases

--- a/src/org/bdinetwork/ishare/client.clj
+++ b/src/org/bdinetwork/ishare/client.clj
@@ -182,9 +182,7 @@
 
 (defmethod ishare->http-request :delegation
   [{{{:keys [policyIssuer]} :delegationRequest :as delegation-mask} :ishare/params :as request}]
-  (prn "delegation!")
   (assert (= policyIssuer (:ishare/policy-issuer request)))
-  (prn "no err")
   (delegation-evidence-request request delegation-mask))
 
 

--- a/test/org/bdinetwork/ishare/client_test.clj
+++ b/test/org/bdinetwork/ishare/client_test.clj
@@ -11,17 +11,17 @@
             [clojure.string :as s]
             [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
-            [org.bdinetwork.ishare.client :as sut]
+            [org.bdinetwork.ishare.client :as client]
             [org.bdinetwork.ishare.jwt :as jwt]
             [org.bdinetwork.ishare.test-helper :refer [run-exec]]))
 
 (defn- ->x5c [v]
   (->> [v "ca"]
        (map #(str "pem/" % ".cert.pem"))
-       (mapcat (comp sut/x5c io/resource))))
+       (mapcat (comp client/x5c io/resource))))
 
 (defn- ->key [v]
-  (-> (str "pem/" v ".key.pem") io/resource sut/private-key))
+  (-> (str "pem/" v ".key.pem") io/resource client/private-key))
 
 (def client-eori "EU.EORI.CLIENT")
 (def client-x5c (->x5c "client"))
@@ -49,7 +49,11 @@
 
 (defn test-get-token [c token]
   (testing "getting an access token"
-    (let [{:keys [uri]} (<!! c)]
+    (let [{:keys [uri exception]} (<!! c)]
+      (when exception
+        (throw (ex-info "Unexpected exception during access-token call"
+                        {:token token}
+                        exception)))
       (is (= (str aa-url "/connect/token") (str uri)))
 
       (>!! c {:status  200
@@ -60,6 +64,87 @@
                                        "expires_in"   3600})}))))
 
 (deftest parties
+  (testing "expired parties token"
+    (let [[c r] (run-exec (client/parties-request client-data nil))]
+
+      (test-get-token c "aa-token")
+
+      (testing "getting parties"
+        (let [{:keys [uri] :as req} (<!! c)]
+          (is (= (str aa-url "/parties") (str uri)))
+          (is (= "Bearer aa-token" (get-in req [:headers "Authorization"])))
+
+          (>!! c {:status  200
+                  :uri     (:uri req)
+                  :headers {"content-type" "application/json"}
+                  :body    (json/json-str
+                            {"parties_token"
+                             (jwt/make-jwt {:iat 0
+                                            :iss aa-eori
+                                            :sub aa-eori
+                                            :aud client-eori}
+                                           aa-private-key
+                                           aa-x5c)})})))
+
+      (let [{:keys [exception]} (<!! c)]
+        (is (s/starts-with? (.getMessage exception) "Token is expired")))
+
+      (is (nil? @r))))
+
+  (testing "wrong certificate chain"
+    (let [[c r] (run-exec (client/parties-request client-data {"active_only" "true"}))]
+
+      (test-get-token c "aa-token")
+
+      (testing "getting parties"
+        (let [{:keys [uri] :as req} (<!! c)]
+          (is (= (str aa-url "/parties?active_only=true") (str uri)))
+          (is (= "Bearer aa-token" (get-in req [:headers "Authorization"])))
+
+          (>!! c {:status  200
+                  :uri     (:uri req)
+                  :headers {"content-type" "application/json"}
+                  :body    (json/json-str
+                            {"parties_token"
+                             (jwt/make-jwt {:iss aa-eori
+                                            :sub aa-eori
+                                            :aud client-eori}
+                                           aa-private-key
+                                           client-x5c)})})))
+
+      (let [{:keys [exception]} (<!! c)]
+        (is exception
+            "exception was raised")
+        (is (= "Message seems corrupt or manipulated"
+               (.getMessage exception))))
+
+      (is (nil? @r))))
+
+  (testing "valid parties token"
+    (let [[c r] (run-exec (client/parties-request client-data {"name" "Party Name"}))]
+
+      (test-get-token c "aa-token")
+
+      (testing "getting parties"
+        (let [{:keys [uri] :as req} (<!! c)]
+          (is (= (str aa-url "/parties?name=Party+Name") (str uri)))
+          (is (= "Bearer aa-token" (-> req :headers (get "Authorization"))))
+
+          (>!! c {:status  200
+                  :uri     (:uri req)
+                  :headers {"content-type" "application/json"}
+                  :body    (json/json-str
+                            {"parties_token"
+                             (jwt/make-jwt {:iss          aa-eori
+                                            :sub          aa-eori
+                                            :aud          client-eori
+                                            :parties_info {:total_count 0, :pageCount 0, :count 0, :data []}}
+                                           aa-private-key
+                                           aa-x5c)})})))
+
+      (is (= 0 (-> @r :ishare/result :parties_info :count))))))
+
+(deftest parties-deprecated-api
   (testing "expired parties token"
     (let [[c r] (run-exec (-> client-data
                               (assoc :ishare/message-type :parties)))]
@@ -111,6 +196,8 @@
                                            client-x5c)})})))
 
       (let [{:keys [exception]} (<!! c)]
+        (is exception
+            "exception was raised")
         (is (= "Message seems corrupt or manipulated"
                (.getMessage exception))))
 
@@ -143,9 +230,70 @@
 
 (deftest delegation
   (testing "getting delegation evidence from an AR"
+    (let [[c r] (run-exec (client/delegation-evidence-request client-data {:delegationRequest {:policyIssuer client-eori}}))]
+      (test-get-token c "aa-token")
+
+      (testing "getting client"
+        (let [{:keys [uri] :as req} (<!! c)]
+          (is (= (str aa-url "/parties/" client-eori) (str uri)))
+          (is (= "Bearer aa-token" (-> req :headers (get "Authorization"))))
+
+          (>!! c {:status  200
+                  :uri     (:uri req)
+                  :headers {"content-type" "application/json"}
+                  :body    (json/json-str
+                            {"party_token"
+                             (jwt/make-jwt {:iss        aa-eori
+                                            :sub        aa-eori
+                                            :aud        client-eori
+                                            :party_info {:authregistery [{:dataspaceID              "other ds-id"
+                                                                          :authorizationRegistryID  "EU.EORI.OTHER"
+                                                                          :authorizationRegistryUrl "https://other.example.com"}
+                                                                         {:dataspaceID              dataspace-id
+                                                                          :authorizationRegistryID  ar-eori
+                                                                          :authorizationRegistryUrl ar-url}
+                                                                         {:dataspaceID              "random ds-id"
+                                                                          :authorizationRegistryID  "EU.EORI.RANDOM"
+                                                                          :authorizationRegistryUrl "https://random.example.com"}]}}
+                                           aa-private-key
+                                           aa-x5c)})})))
+
+      (testing "get token at AR"
+        (let [{:keys [uri]} (<!! c)]
+          (is (= (str ar-url "/connect/token") (str uri)))
+
+          (>!! c {:status  200
+                  :uri     uri
+                  :headers {"content-type" "application/json"}
+                  :body    (json/json-str {"access_token" "ar-token"
+                                           "token_type"   "Bearer",
+                                           "expires_in"   3600})})))
+
+      (testing "delegation call"
+        (let [{:keys [uri] :as req} (<!! c)]
+          (is (= (str ar-url "/delegation") (str uri)))
+          (is (= "Bearer ar-token" (get-in req [:headers "Authorization"])))
+
+          (>!! c {:status  200
+                  :uri     uri
+                  :headers {"content-type" "application/json"}
+                  :body    (json/json-str
+                            {"delegation_token"
+                             (jwt/make-jwt {:iss                ar-eori
+                                            :sub                ar-eori
+                                            :aud                client-eori
+                                            :delegationEvidence "test"}
+                                           ar-private-key
+                                           ar-x5c)})})))
+
+      (is (= "test" (-> @r :ishare/result :delegationEvidence))))))
+
+(deftest delegation-deprecated-api
+  (testing "getting delegation evidence from an AR"
     (let [[c r] (run-exec (-> client-data
                               (assoc :ishare/message-type :delegation
-                                     :ishare/policy-issuer client-eori)))]
+                                     :ishare/policy-issuer client-eori
+                                     :ishare/params {:delegationRequest {:policyIssuer client-eori}})))]
       (test-get-token c "aa-token")
 
       (testing "getting client"

--- a/test/org/bdinetwork/ishare/client_test.clj
+++ b/test/org/bdinetwork/ishare/client_test.clj
@@ -27,10 +27,10 @@
 (def client-x5c (->x5c "client"))
 (def client-private-key (->key "client"))
 
-(def aa-eori "EU.EORI.AA")
-(def aa-url "https://aa.example.com")
-(def aa-x5c (->x5c "aa"))
-(def aa-private-key (->key "aa"))
+(def satellite-eori "EU.EORI.AA")
+(def satellite-url "https://satellite.example.com")
+(def satellite-x5c (->x5c "aa"))
+(def satellite-private-key (->key "aa"))
 
 (def ar-eori "EU.EORI.AR")
 (def ar-url "https://ar.example.com")
@@ -44,17 +44,18 @@
    :ishare/private-key        client-private-key
    :ishare/x5c                client-x5c
    :ishare/dataspace-id       dataspace-id
-   :ishare/satellite-id       aa-eori
-   :ishare/satellite-base-url aa-url})
+   :ishare/satellite-id       satellite-eori
+   :ishare/satellite-base-url satellite-url})
 
-(defn test-get-token [c token]
-  (testing "getting an access token"
+(defn test-get-token [c base-url token]
+  (testing (str "Getting an access token for " base-url)
     (let [{:keys [uri exception]} (<!! c)]
       (when exception
         (throw (ex-info "Unexpected exception during access-token call"
                         {:token token}
                         exception)))
-      (is (= (str aa-url "/connect/token") (str uri)))
+      (is (= (str base-url "/connect/token") (str uri))
+          "Correct url for access token")
 
       (>!! c {:status  200
               :uri     uri
@@ -67,14 +68,14 @@
   (testing "expired parties token"
     (let [[c r] (run-exec (client/parties-request client-data nil))]
 
-      (test-get-token c "aa-token")
+      (test-get-token c satellite-url "satellite-token")
 
       (testing "Getting parties"
         (let [{:keys [uri] :as req} (<!! c)]
-          (is (= (str aa-url "/parties")
+          (is (= (str satellite-url "/parties")
                  (str uri) ;; is a java.net.URI
                  ))
-          (is (= "Bearer aa-token" (get-in req [:headers "Authorization"])))
+          (is (= "Bearer satellite-token" (get-in req [:headers "Authorization"])))
 
           (>!! c {:status  200
                   :uri     uri
@@ -84,11 +85,11 @@
                              (jwt/make-jwt {:iat 0
                                             ;; Too old; will be rejected, since make-jwt
                                             ;; will set exp to iat + 30 seconds.
-                                            :iss aa-eori
-                                            :sub aa-eori
+                                            :iss satellite-eori
+                                            :sub satellite-eori
                                             :aud client-eori}
-                                           aa-private-key
-                                           aa-x5c)})})))
+                                           satellite-private-key
+                                           satellite-x5c)})})))
 
       (let [{:keys [exception]} (<!! c)]
         (is exception
@@ -101,24 +102,24 @@
   (testing "wrong certificate chain"
     (let [[c r] (run-exec (client/parties-request client-data {"active_only" "true"}))]
 
-      (test-get-token c "aa-token")
+      (test-get-token c satellite-url "satellite-token")
 
       (testing "getting parties"
         (let [{:keys [uri] :as req} (<!! c)]
-          (is (= (str aa-url "/parties?active_only=true") (str uri)))
-          (is (= "Bearer aa-token" (get-in req [:headers "Authorization"])))
+          (is (= (str satellite-url "/parties?active_only=true") (str uri)))
+          (is (= "Bearer satellite-token" (get-in req [:headers "Authorization"])))
 
           (>!! c {:status  200
                   :uri     (:uri req)
                   :headers {"content-type" "application/json"}
                   :body    (json/json-str
                             {"parties_token"
-                             (jwt/make-jwt {:iss aa-eori
-                                            :sub aa-eori
+                             (jwt/make-jwt {:iss satellite-eori
+                                            :sub satellite-eori
                                             :aud client-eori}
-                                           aa-private-key
+                                           satellite-private-key
                                            ;; we use `client-x5c`
-                                           ;; instead of `aa-x5c`, so
+                                           ;; instead of `satellite-x5c`, so
                                            ;; the certificate chain
                                            ;; does not match the
                                            ;; private key.
@@ -138,94 +139,108 @@
   (testing "valid parties token"
     (let [[c r] (run-exec (client/parties-request client-data {"name" "Party Name"}))]
 
-      (test-get-token c "aa-token")
+      (test-get-token c satellite-url "satellite-token")
 
       (testing "getting parties"
         (let [{:keys [uri] :as req} (<!! c)]
-          (is (= (str aa-url "/parties?name=Party+Name") (str uri)))
-          (is (= "Bearer aa-token" (-> req :headers (get "Authorization"))))
+          (is (= (str satellite-url "/parties?name=Party+Name") (str uri)))
+          (is (= "Bearer satellite-token" (-> req :headers (get "Authorization"))))
 
           (>!! c {:status  200
                   :uri     (:uri req)
                   :headers {"content-type" "application/json"}
                   :body    (json/json-str
                             {"parties_token"
-                             (jwt/make-jwt {:iss          aa-eori
-                                            :sub          aa-eori
+                             (jwt/make-jwt {:iss          satellite-eori
+                                            :sub          satellite-eori
                                             :aud          client-eori
                                             :parties_info {:total_count 1,
-                                                           :pageCount 1,
-                                                           :count 1,
-                                                           :data [{:party_id "EU.EORI.CLIENT"
-                                                                   :adherence {:status "Active"}}]}}
-                                           aa-private-key
-                                           aa-x5c)})})))
+                                                           :pageCount   1,
+                                                           :count       1,
+                                                           :data        [{:party_id  "EU.EORI.CLIENT"
+                                                                          :adherence {:status     "Active"
+                                                                                      :start_date "2024-10-01T07:40:25.597636Z"
+                                                                                      :end_date   "2124-10-01T07:40:25.597636Z"}}]}}
+                                           satellite-private-key
+                                           satellite-x5c)})})))
 
       (is (= 1 (-> @r :ishare/result :parties_info :count))))))
 
 (deftest delegation
-  (testing "Getting delegation evidence from an AR"
-    (let [[c r] (run-exec (client/delegation-evidence-request client-data
-                                                              {:delegationRequest
-                                                               {:policyIssuer client-eori}}))]
-      (test-get-token c "aa-token")
+  (testing "Delegation evidence request"
+    ;; use fresh party-info-cache for repeatable tests
+    (binding [client/*party-info-fn* (client/mk-party-info-cached 60000)]
+      (let [[c r] (run-exec (client/delegation-evidence-request client-data
+                                                                {:delegationRequest
+                                                                 {:policyIssuer client-eori}}))]
+        (test-get-token c satellite-url "satellite-token")
 
-      (testing "Getting party info to retreive AR location"
-        (let [{:keys [uri] :as req} (<!! c)]
-          (is (= (str aa-url "/parties/" client-eori) (str uri)))
-          (is (= "Bearer aa-token" (-> req :headers (get "Authorization"))))
+        (testing "Getting party info to retreive AR location"
+          (let [{:keys [uri] :as req} (<!! c)]
+            (is (= (str satellite-url "/parties/" client-eori) (str uri)))
+            (is (= "Bearer satellite-token" (-> req :headers (get "Authorization"))))
 
-          (>!! c {:status  200
-                  :uri     (:uri req)
-                  :headers {"content-type" "application/json"}
-                  :body    (json/json-str
-                            {"party_token"
-                             (jwt/make-jwt {:iss        aa-eori
-                                            :sub        aa-eori
-                                            :aud        client-eori
-                                            :party_info {:authregistery [{:dataspaceID              "other ds-id"
-                                                                          :authorizationRegistryID  "EU.EORI.OTHER"
-                                                                          :authorizationRegistryUrl "https://other.example.com"}
-                                                                         {:dataspaceID              dataspace-id
-                                                                          :authorizationRegistryID  ar-eori
-                                                                          :authorizationRegistryUrl ar-url}
-                                                                         {:dataspaceID              "random ds-id"
-                                                                          :authorizationRegistryID  "EU.EORI.RANDOM"
-                                                                          :authorizationRegistryUrl "https://random.example.com"}]}}
-                                           aa-private-key
-                                           aa-x5c)})})))
+            (>!! c {:status  200
+                    :uri     (:uri req)
+                    :headers {"content-type" "application/json"}
+                    :body    (json/json-str
+                              {"party_token"
+                               (jwt/make-jwt {:iss        satellite-eori
+                                              :sub        satellite-eori
+                                              :aud        client-eori
+                                              :party_info {:authregistery [{:dataspaceID              "other ds-id"
+                                                                            :authorizationRegistryID  "EU.EORI.OTHER"
+                                                                            :authorizationRegistryUrl "https://other.example.com"}
+                                                                           {:dataspaceID              dataspace-id
+                                                                            :authorizationRegistryID  ar-eori
+                                                                            :authorizationRegistryUrl ar-url}
+                                                                           {:dataspaceID              "random ds-id"
+                                                                            :authorizationRegistryID  "EU.EORI.RANDOM"
+                                                                            :authorizationRegistryUrl "https://random.example.com"}]}}
+                                             satellite-private-key
+                                             satellite-x5c)})})))
 
-      (testing "Get token at AR"
-        (let [{:keys [uri]} (<!! c)]
-          (is (= (str ar-url "/connect/token")
-                 (str uri) ;; uri is a java.net.URI
-                 ))
+        (testing "Get AR provider's party info"
+          (test-get-token c satellite-url "satellite-token")
 
-          (>!! c {:status  200
-                  :uri     uri
-                  :headers {"content-type" "application/json"}
-                  :body    (json/json-str {"access_token" "ar-token"
-                                           "token_type"   "Bearer",
-                                           "expires_in"   3600})})))
+          (let [{:keys [uri] :as req} (<!! c)]
+            (is (= (str satellite-url "/parties/" ar-eori) (str uri)))
+            (is (= "Bearer satellite-token" (-> req :headers (get "Authorization"))))
 
-      (testing "Get delegation evidence from AR"
-        (let [{:keys [uri] :as req} (<!! c)]
-          (is (= (str ar-url "/delegation") (str uri)))
-          (is (= "Bearer ar-token" (get-in req [:headers "Authorization"])))
+            (>!! c {:status  200
+                    :headers {"content-type" "application/json"}
+                    :body    (json/json-str
+                              {"party_token"
+                               (jwt/make-jwt {:iss        satellite-eori
+                                              :sub        satellite-eori
+                                              :aud        client-eori
+                                              :party_info {
+                                                           :adherence {:status     "Active"
+                                                                       :start_date "2024-10-01T07:40:25.597636Z"
+                                                                       :end_date   "2124-10-01T07:40:25.597636Z"}}}
+                                             satellite-private-key
+                                             satellite-x5c)})})))
 
-          (>!! c {:status  200
-                  :uri     uri
-                  :headers {"content-type" "application/json"}
-                  :body    (json/json-str
-                            {"delegation_token"
-                             (jwt/make-jwt {:iss                ar-eori
-                                            :sub                ar-eori
-                                            :aud                client-eori
-                                            :delegationEvidence "test"}
-                                           ar-private-key
-                                           ar-x5c)})})))
+        (testing "Get delegation evidence from AR"
+          (test-get-token c ar-url "ar-token")
 
-      (is (= "test" (-> @r :ishare/result :delegationEvidence))))))
+          (let [{:keys [uri] :as req} (<!! c)]
+            (is (= (str ar-url "/delegation") (str uri)))
+            (is (= "Bearer ar-token" (get-in req [:headers "Authorization"])))
+
+            (>!! c {:status  200
+                    :uri     uri
+                    :headers {"content-type" "application/json"}
+                    :body    (json/json-str
+                              {"delegation_token"
+                               (jwt/make-jwt {:iss                ar-eori
+                                              :sub                ar-eori
+                                              :aud                client-eori
+                                              :delegationEvidence "test"}
+                                             ar-private-key
+                                             ar-x5c)})})))
+
+        (is (= "test" (-> @r :ishare/result :delegationEvidence)))))))
 
 (def base-request
   (assoc client-data

--- a/test/org/bdinetwork/ishare/test_helper.clj
+++ b/test/org/bdinetwork/ishare/test_helper.clj
@@ -24,7 +24,7 @@
   "Run ishare client exec asynchronously returning a channel and a result future.
 
   The returns channel is bi-directional it delivers ring like request
-  map and expects ring like response maps."
+  map and expects ring like response map."
   [req]
   (let [c (async/chan)]
     [c (binding [ishare-client/http-client (build-client c)]


### PR DESCRIPTION
This deprecates the old ishare->http-request multimethod in favor of named request functions. The multimethod API remains working until depending code has been migrated to the new API.